### PR TITLE
fix RecvByte() for multi-byte i2c reads --sq5bpf

### DIFF
--- a/usdx.ino
+++ b/usdx.ino
@@ -1317,13 +1317,15 @@ public:
     data |= RecvBit(1 << 0);
     if(last){
       I2C_SDA_HI();  // NACK
+      DELAY(I2C_DELAY);
+      I2C_SCL_LO();
     } else {
       I2C_SDA_LO();  // ACK
+      I2C_SCL_HI();
+      DELAY(I2C_DELAY);
+      I2C_SCL_LO(); // DELAY(I2C_DELAY);
+      I2C_SDA_HI(); 
     }
-    DELAY(I2C_DELAY);
-    I2C_SCL_HI();
-    I2C_SDA_HI();    // restore SDA for read
-    I2C_SCL_LO();
     return data;
   }
   inline void resume(){


### PR DESCRIPTION
Fix RecvByte() ACK/NACK behaviour in case where it is used to read multiple bytes from a device. 
Currently this function is used only to read 1-byte values from SI5351/M5351, so this bug was not exposed.

VY 73
Jacek / SQ5BPF